### PR TITLE
feat: Add email translations based on user language preference

### DIFF
--- a/api/wildfire_assessment/svc/processor.py
+++ b/api/wildfire_assessment/svc/processor.py
@@ -5,11 +5,15 @@ import time
 
 import ee
 from celery import shared_task
+from django.contrib.auth import get_user_model
 from dotenv import load_dotenv
 from wildfire_analyser.fire_assessment.deliverables import Deliverable
 from wildfire_analyser.fire_assessment.post_fire_assessment import PostFireAssessment
 from wildfire_assessment.svc.aws import get_aws_secret_manager_secret
+from wildfire_assessment.translations import get_email_translation
 from wildfire_assessment.utils import send_gmail_email
+
+User = get_user_model()
 
 logger = logging.getLogger(__name__)
 load_dotenv()
@@ -142,15 +146,27 @@ def process_scientific_deliverable(
     result_wait = wait_for_task(result["scientific"][deliverable_key]["gee_task_id"])
 
     if result_wait == "COMPLETED":
+        # Get user's language preference, default to English
+        language = "en"
+        try:
+            user = User.objects.filter(email=email).first()
+            if user and hasattr(user, "profile"):
+                language = user.profile.default_language or "en"
+        except Exception:
+            pass  # Fall back to English on any error
+
+        subject = get_email_translation(language, "email.subject")
+        body = get_email_translation(language, "email.body").format(
+            reserve_name=reserve_name,
+            url=result["scientific"][deliverable_key]["url"],
+        )
+
         send_gmail_email(
             username="Brazil@flyinglabs.org",
             password=json.loads(get_aws_secret_manager_secret(ENV))["GMAIL_PWD"],
             to_address=email,
-            subject="Wildfire Analyser - Scientific Deliverable Ready",
-            body=(
-                f"The scientific deliverable '{reserve_name}' is ready for download on"
-                f" this link: {result['scientific'][deliverable_key]['url']}"
-            ),
+            subject=subject,
+            body=body,
         )
 
     return result_wait

--- a/api/wildfire_assessment/tests/test_translations.py
+++ b/api/wildfire_assessment/tests/test_translations.py
@@ -1,0 +1,65 @@
+from django.test import TestCase
+from wildfire_assessment.translations import EMAIL_TRANSLATIONS, get_email_translation
+
+
+class EmailTranslationsTestCase(TestCase):
+    """Tests for email translation functionality."""
+
+    def test_get_email_translation_english(self):
+        """Test getting English translations."""
+        subject = get_email_translation("en", "email.subject")
+        self.assertEqual(subject, "Wildfire Analyser - Scientific Deliverable Ready")
+
+        body = get_email_translation("en", "email.body")
+        self.assertIn("{reserve_name}", body)
+        self.assertIn("{url}", body)
+
+    def test_get_email_translation_portuguese(self):
+        """Test getting Portuguese translations."""
+        subject = get_email_translation("pt-BR", "email.subject")
+        self.assertEqual(subject, "Wildfire Analyser - Produto Científico Pronto")
+
+        body = get_email_translation("pt-BR", "email.body")
+        self.assertIn("{reserve_name}", body)
+        self.assertIn("{url}", body)
+
+    def test_get_email_translation_french(self):
+        """Test getting French translations."""
+        subject = get_email_translation("fr", "email.subject")
+        self.assertEqual(subject, "Wildfire Analyser - Livrable Scientifique Prêt")
+
+        body = get_email_translation("fr", "email.body")
+        self.assertIn("{reserve_name}", body)
+        self.assertIn("{url}", body)
+
+    def test_get_email_translation_fallback_to_english(self):
+        """Test that unknown languages fall back to English."""
+        subject = get_email_translation("de", "email.subject")
+        self.assertEqual(subject, "Wildfire Analyser - Scientific Deliverable Ready")
+
+    def test_get_email_translation_unknown_key_returns_key(self):
+        """Test that unknown keys return the key itself."""
+        result = get_email_translation("en", "unknown.key")
+        self.assertEqual(result, "unknown.key")
+
+    def test_all_languages_have_same_keys(self):
+        """Test that all languages have the same translation keys."""
+        english_keys = set(EMAIL_TRANSLATIONS["en"].keys())
+
+        for lang, translations in EMAIL_TRANSLATIONS.items():
+            self.assertEqual(
+                set(translations.keys()),
+                english_keys,
+                f"Language '{lang}' has different keys than English",
+            )
+
+    def test_body_format_placeholders(self):
+        """Test that body translations can be formatted with placeholders."""
+        for lang in EMAIL_TRANSLATIONS:
+            body = get_email_translation(lang, "email.body")
+            formatted = body.format(
+                reserve_name="Test Reserve",
+                url="https://example.com/download",
+            )
+            self.assertIn("Test Reserve", formatted)
+            self.assertIn("https://example.com/download", formatted)

--- a/api/wildfire_assessment/translations.py
+++ b/api/wildfire_assessment/translations.py
@@ -1,0 +1,47 @@
+"""
+Email translations for the Wildfire Assessment platform.
+
+Translations follow the same language codes as the UI:
+- en: English
+- pt-BR: Português (Brasil)
+- fr: Français
+"""
+
+EMAIL_TRANSLATIONS = {
+    "en": {
+        "email.subject": "Wildfire Analyser - Scientific Deliverable Ready",
+        "email.body": (
+            "The scientific deliverable '{reserve_name}' is ready for download on"
+            " this link: {url}"
+        ),
+    },
+    "pt-BR": {
+        "email.subject": "Wildfire Analyser - Produto Científico Pronto",
+        "email.body": (
+            "O produto científico '{reserve_name}' está pronto para download"
+            " neste link: {url}"
+        ),
+    },
+    "fr": {
+        "email.subject": "Wildfire Analyser - Livrable Scientifique Prêt",
+        "email.body": (
+            "Le livrable scientifique '{reserve_name}' est prêt à être téléchargé"
+            " via ce lien : {url}"
+        ),
+    },
+}
+
+
+def get_email_translation(language: str, key: str) -> str:
+    """
+    Get a translated email string for the given language and key.
+
+    Args:
+        language: Language code (en, pt-BR, fr)
+        key: Translation key (e.g., 'email.subject', 'email.body')
+
+    Returns:
+        Translated string, falls back to English if language not found.
+    """
+    translations = EMAIL_TRANSLATIONS.get(language, EMAIL_TRANSLATIONS["en"])
+    return translations.get(key, EMAIL_TRANSLATIONS["en"].get(key, key))


### PR DESCRIPTION
## Summary
Adds internationalization support for the scientific deliverable notification emails.

## Changes
- **`api/wildfire_assessment/translations.py`** (new)
  - Email translations for English, Portuguese (Brazil), and French
  - `get_email_translation(language, key)` helper with English fallback

- **`api/wildfire_assessment/svc/processor.py`** (updated)
  - Imports User model and translation helper
  - Looks up user by email → gets `profile.default_language`
  - Uses translated subject/body for the notification email

- **`api/wildfire_assessment/tests/test_translations.py`** (new)
  - Tests for all languages, fallback behavior, and placeholder formatting

## How it works
When a scientific deliverable is ready, the system:
1. Looks up the user by their email address
2. Gets their `default_language` from their UserProfile
3. Sends the email in their preferred language (falls back to English if not found)

## Languages supported
- 🇺🇸 English (en)
- 🇧🇷 Português - Brasil (pt-BR)
- 🇫🇷 Français (fr)