### PR TITLE
fix: correct SSL cert paths in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - "8081:8000"
       - "4011:3011"
     command: >
-      sh -c "python manage.py migrate && opentelemetry-instrument python manage.py runserver_plus 0.0.0.0:8000 --cert-file cert.crt --key-file cert.key"
+      sh -c "python manage.py migrate && opentelemetry-instrument python manage.py runserver_plus 0.0.0.0:8000 --cert-file /api/cert.crt --key-file /api/cert.key"
     volumes:
       - ./api:/api
       - ./polygons:/polygons


### PR DESCRIPTION
Use absolute paths for SSL certificates in runserver_plus command.

## Changes
- Changed `cert.crt` → `/api/cert.crt`
- Changed `cert.key` → `/api/cert.key`

## Why
The certificates are in the `/api` volume mount, so absolute paths are needed for the container to find them.